### PR TITLE
coroot: add Annotations field to ServiceSpec and update service creation logic

### DIFF
--- a/api/v1/coroot_types.go
+++ b/api/v1/coroot_types.go
@@ -43,6 +43,8 @@ type ServiceSpec struct {
 	Port int32 `json:"port,omitempty"`
 	// NodePort number (if type is NodePort).
 	NodePort int32 `json:"nodePort,omitempty"`
+	// Annotations for the service.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 type StorageSpec struct {

--- a/controller/coroot.go
+++ b/controller/coroot.go
@@ -54,6 +54,7 @@ func (r *CorootReconciler) corootService(cr *corootv1.Coroot) *corev1.Service {
 	s.Spec = corev1.ServiceSpec{
 		Selector: ls,
 		Type:     cr.Spec.Service.Type,
+		Annotations: cr.Spec.Service.Annotations,
 		Ports: []corev1.ServicePort{
 			{
 				Name:       "http",


### PR DESCRIPTION
This update to the Coroot Operator introduces the ability to specify custom annotations for the Kubernetes Service resource that the operator manages. This enhancement provides users with greater flexibility to integrate the coroot service with other tools or to leverage specific Kubernetes features that rely on service annotations.